### PR TITLE
Group dash packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,12 @@
   "extends": [
     "config:base"
   ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [ "dash" ],
+      "groupName": "dash"
+    }
+  ],
   "pip_requirements": {
     "fileMatch": ["requirements-dev", "requirements$"]
   },


### PR DESCRIPTION
Some dash packages require specific versions. The packages were grouped to avoid problems during renovate updates, such as observed in #8, #9, #10 and #11.